### PR TITLE
Promote prompt-tester, auto-prompter, text-summarizer to AI catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Single table; **`category`** matches hub tabs in [`main/main.js`](main/main.js).
 | Math | `solar-system` | Static | Orbital visualization |
 | AI | `token-counter` | Static | Count tokens |
 | AI | `context-packer` | Static | Pack context for LLMs |
+| AI | `prompt-tester` | Static | Compare prompts locally |
+| AI | `auto-prompter` | Static | Chain prompts locally |
+| AI | `text-summarizer` | Static | Summarize text locally |
 | Tools | `aspect-ratio` | Static | Image dimension calculator |
 | Tools | `countdown-timer` | Static | Countdown to date |
 | Tools | `dna-helix` | Static | 3D DNA visualization |
@@ -74,6 +77,8 @@ Single table; **`category`** matches hub tabs in [`main/main.js`](main/main.js).
 | Tools | `epoch-converter` | Static | Unix time and locale dates |
 | Tools | `password-generator` | Static | Random passwords |
 
+Promoted from lab to the AI tab: `prompt-tester`, `auto-prompter`, `text-summarizer`.
+
 **Static** = static HTML/CSS/JS (no repo `package.json` deps for these). URL pattern: **`/{slug}/`**.
 
 ---
@@ -85,9 +90,6 @@ Grid-only on homepage; **not** first-class linked cards. **`surface`** is the ba
 | Slug | Surface | Summary |
 |------|---------|---------|
 | `ascii-art` | Web | Generate ASCII art from text |
-| `auto-prompter` | Web | Prompt chaining and automation |
-| `prompt-tester` | Web | Test and compare AI prompts |
-| `text-summarizer` | Web | Summarize text with AI |
 | `pdf-summarizer` | Web | Extract and summarize PDF content in-browser |
 | `image-analyzer` | Web | Inspect images with captions and metadata locally |
 | `code-explainer` | Web | Explain snippets or files without leaving the tab |

--- a/auto-prompter/index.html
+++ b/auto-prompter/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Auto-Prompter — Pablobot</title>
+  <meta name="description" content="Chain and distill prompts—local scripts in this repo.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pablobot.com/auto-prompter/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pablobot.com/auto-prompter/">
+  <meta property="og:title" content="Auto-Prompter — Pablobot">
+  <meta property="og:description" content="Chain and distill prompts—local scripts in this repo.">
+  <meta property="og:image" content="https://pablobot.com/main/assets/hero/architecture-gallery-hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Auto-Prompter — Pablobot">
+  <meta name="twitter:description" content="Chain and distill prompts—local scripts in this repo.">
+  <meta name="theme-color" content="#0d0f17">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='%23171717'>P</text></svg>">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d0f17; --surface:#161925; --border:#2a2f45; --accent:#6c63ff; --text:#e8eaf6; --muted:#9ca3af; --radius:12px; }
+    body { font-family: system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; line-height: 1.5; }
+    a { color: var(--accent); }
+    .app-header { border-bottom: 1px solid var(--border); background: rgba(22,25,37,.92); }
+    .app-header-inner { max-width: 720px; margin: 0 auto; padding: 1rem 1.25rem; }
+    .back-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; display: inline-block; margin-bottom: 0.5rem; }
+    .back-link:hover { color: var(--text); }
+    h1 { font-size: 1.35rem; font-weight: 700; }
+    .sub { color: var(--muted); font-size: 0.9rem; margin-top: 0.25rem; }
+    .container { max-width: 720px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; margin-top: 1rem; }
+    .card p { margin-bottom: 0.75rem; color: var(--text); font-size: 0.95rem; }
+    .card p:last-child { margin-bottom: 0; }
+    .tool-more { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 1.5rem; padding: 0 1.25rem; line-height: 1.6; }
+    .tool-more a { margin: 0 0.35rem; white-space: nowrap; }
+    footer { max-width: 720px; margin: 2rem auto 0; padding: 1rem 1.25rem 2rem; border-top: 1px solid var(--border); font-size: 0.78rem; color: var(--muted); text-align: center; }
+  </style>
+</head>
+<body>
+  <header class="app-header">
+    <div class="app-header-inner">
+      <a class="back-link" href="../">← Pablobot</a>
+      <h1>Auto-Prompter</h1>
+      <p class="sub">Chain prompts with small local scripts.</p>
+    </div>
+  </header>
+  <main class="container">
+    <div class="card">
+      <p>This folder holds Python helpers for prompt chaining. Nothing runs in the browser here.</p>
+      <p><a href="https://github.com/Catalitium/pablot/tree/main/auto-prompter">View source on GitHub</a></p>
+    </div>
+  </main>
+  <nav class="tool-more" aria-label="More Pablobot utilities">
+    Also try:
+    <a href="/token-counter/">Token Counter</a>
+    <a href="/context-packer/">Context Packer</a>
+    <a href="/json-formatter/">JSON Formatter</a>
+  </nav>
+  <footer>Open source · Part of <a href="../">Pablobot</a></footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
   }
   </script>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="/manifest.webmanifest">
 </head>
 <body>
   <!-- Header -->
@@ -53,6 +54,7 @@
     </div>
 
     <nav class="header-nav" aria-label="Quick links">
+      <button type="button" class="header-nav-btn" id="themeToggle" aria-label="Toggle color theme" aria-pressed="false">🌙</button>
       <a href="https://github.com/Catalitium/pablot" target="_blank" rel="noopener noreferrer"
          class="header-nav-btn header-nav-gh" aria-label="GitHub repository">
         <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18" aria-hidden="true">
@@ -72,14 +74,12 @@
       <p class="hero-stats" id="heroStats" aria-live="polite"></p>
       <div class="hero-actions">
         <button type="button" class="hero-btn hero-btn--primary" id="heroBrowseBtn">Browse tools</button>
-        <a href="main/reference/" class="hero-btn hero-btn--secondary">Reference hub</a>
+        <a href="reference/" class="hero-btn hero-btn--secondary">Reference hub</a>
       </div>
       <div class="hero-actions hero-actions--secondary" role="group" aria-label="Reference libraries">
-        <button type="button" class="hero-btn hero-btn--secondary" id="aiModelsBtn" aria-expanded="false" aria-haspopup="dialog">LLM diagram gallery</button>
-        <button type="button" class="hero-btn hero-btn--secondary" id="cryptoBtn" aria-expanded="false" aria-haspopup="dialog">Blockchain maps</button>
-        <a href="main/reference/models/" class="hero-btn hero-btn--ghost">LLM models</a>
-        <a href="main/reference/compare/models.html" class="hero-btn hero-btn--ghost">Compare models</a>
-        <a href="main/reference/chains/" class="hero-btn hero-btn--ghost">Blockchain chains</a>
+        <a href="reference/models/" class="hero-btn hero-btn--secondary">LLM models</a>
+        <a href="reference/compare/models.html" class="hero-btn hero-btn--ghost">Compare models</a>
+        <a href="reference/chains/" class="hero-btn hero-btn--ghost">Blockchain chains</a>
       </div>
     </div>
 
@@ -140,7 +140,7 @@
       <!-- Hero -->
       <section class="gallery-hero" aria-label="Reference hero">
         <img
-          src="main/assets/hero/architecture-gallery-hero.webp"
+          src="assets/hero/architecture-gallery-hero.webp"
           alt="Abstract visualization of neural network architectures and large language model families including DeepSeek, Qwen3, Llama 4, and Mistral"
           class="gallery-hero-img"
           loading="lazy"

--- a/main.js
+++ b/main.js
@@ -37,6 +37,15 @@ const chainPageTemplate = `<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{name}} — Pablobot</title>
   <meta name="description" content="{{name}} blockchain: {{layer}} layer, {{consensus}} consensus mechanism, launched {{year}}.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pablobot.com/main/reference/chains/{{id}}.html">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://pablobot.com/main/reference/chains/{{id}}.html">
+  <meta property="og:title" content="{{name}} — Pablobot">
+  <meta property="og:description" content="{{name}} blockchain reference — {{layer}}, {{consensus}}, {{year}}.">
+  <meta property="og:image" content="https://pablobot.com/main/assets/hero/architecture-gallery-hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{name}} — Pablobot">
   <link rel="stylesheet" href="../../../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='%23171717'>P</text></svg>">
   <style>
@@ -108,6 +117,7 @@ const chainPageTemplate = `<!DOCTYPE html>
 
 REF_CHAIN_ROWS.forEach(c => {
   const html = chainPageTemplate
+    .replace(/\{\{id\}\}/g, c.id)
     .replace(/\{\{name\}\}/g, c.name)
     .replace(/\{\{ticker\}\}/g, c.ticker)
     .replace(/\{\{layer\}\}/g, c.layer)
@@ -163,6 +173,15 @@ const modelPageTemplate = `<!DOCTYPE html>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{name}} — Pablobot</title>
   <meta name="description" content="{{name}} AI model: {{params}} parameters, {{context}} context.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pablobot.com/main/reference/models/{{id}}.html">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://pablobot.com/main/reference/models/{{id}}.html">
+  <meta property="og:title" content="{{name}} — Pablobot">
+  <meta property="og:description" content="{{name}} — {{params}}, {{context}} context. LLM reference on Pablobot.">
+  <meta property="og:image" content="https://pablobot.com/main/assets/hero/architecture-gallery-hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{name}} — Pablobot">
   <link rel="stylesheet" href="../../../style.css">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='%23171717'>P</text></svg>">
   <style>
@@ -249,6 +268,7 @@ REF_MODEL_ROWS.forEach(m => {
     : '';
 
   let html = modelPageTemplate
+    .replace(/\{\{id\}\}/g, m.id)
     .replace(/\{\{name\}\}/g, m.name)
     .replace(/\{\{family\}\}/g, m.family)
     .replace(/\{\{provider\}\}/g, m.provider)
@@ -267,6 +287,57 @@ REF_MODEL_ROWS.forEach(m => {
   console.log('Created:', m.id + '.html');
 });
   console.log("Reference pages written: reference/chains/, reference/models/");
+
+  // Sitemap: derived from TOOLS slugs in this file + reference routes (single source of truth for crawl lists).
+  const SITE = "https://pablobot.com";
+  const mainJsPath = path.join(__dirname, "main.js");
+  const srcBundle = fs.readFileSync(mainJsPath, "utf8");
+  const toolsMarker = "const TOOLS = [";
+  // Browser bundle also assigns toolsMarker string constant above — use last occurrence for real TOOLS array.
+  const toolsIdx = srcBundle.lastIndexOf(toolsMarker);
+  if (toolsIdx === -1) throw new Error("Sitemap: const TOOLS block not found in main.js");
+  let depth = 1;
+  let pos = toolsIdx + toolsMarker.length;
+  while (pos < srcBundle.length && depth > 0) {
+    const ch = srcBundle[pos++];
+    if (ch === "[") depth++;
+    else if (ch === "]") depth--;
+  }
+  const toolsSlice = srcBundle.slice(toolsIdx + toolsMarker.length, pos - 1);
+  const toolSlugs = [...new Set([...toolsSlice.matchAll(/slug:"([^"]+)"/g)].map((m) => m[1]))].filter((s) =>
+    /^[a-z0-9-]+$/.test(s)
+  );
+  const locs = new Set();
+  locs.add(`${SITE}/`);
+  toolSlugs.forEach((s) => locs.add(`${SITE}/${s}/`));
+  const refIndexPaths = [
+    "/main/reference/",
+    "/main/reference/models/",
+    "/main/reference/chains/",
+    "/main/reference/compare/models.html",
+    "/main/reference/compare/chains.html",
+    "/main/reference/concepts/",
+    "/main/reference/families/",
+  ];
+  refIndexPaths.forEach((p) => locs.add(SITE + p));
+  REF_CHAIN_ROWS.forEach((c) => locs.add(`${SITE}/main/reference/chains/${c.id}.html`));
+  REF_MODEL_ROWS.forEach((m) => locs.add(`${SITE}/main/reference/models/${m.id}.html`));
+
+  const xmlEsc = (u) =>
+    u.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+  const urlEntries = [...locs]
+    .sort()
+    .map((loc) => `  <url><loc>${xmlEsc(loc)}</loc></url>`)
+    .join("\n");
+  const sitemapBody = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlEntries}
+</urlset>
+`;
+  const siteRoot = path.join(__dirname, "..");
+  fs.writeFileSync(path.join(siteRoot, "sitemap.xml"), sitemapBody);
+  console.log("Created: sitemap.xml");
+
   process.exit(0);
 })();
 
@@ -318,6 +389,9 @@ REF_MODEL_ROWS.forEach(m => {
       // AI
       {name:"Token Counter",slug:"token-counter",category:"ai",icon:"🔢",desc:"Count tokens"},
       {name:"Context Packer",slug:"context-packer",category:"ai",icon:"📦",desc:"Pack context for LLMs"},
+      {name:"Prompt Tester",slug:"prompt-tester",category:"ai",icon:"💬",desc:"Compare prompts locally"},
+      {name:"Auto-Prompter",slug:"auto-prompter",category:"ai",icon:"🤖",desc:"Chain prompts locally"},
+      {name:"Text Summarizer",slug:"text-summarizer",category:"ai",icon:"📝",desc:"Summarize text locally"},
 
       // Tools
       {name:"Aspect Ratio",slug:"aspect-ratio",category:"tools",icon:"📐",desc:"Image dimension calculator"},
@@ -569,9 +643,6 @@ REF_MODEL_ROWS.forEach(m => {
     const WIP_TOOLS = [
       // No production index.html yet
       { name:"ASCII Art",           slug:"ascii-art",           icon:"🎨", desc:"Generate ASCII art from text",           type:"Web" },
-      { name:"Auto-Prompter",       slug:"auto-prompter",       icon:"🤖", desc:"Prompt chaining and automation",         type:"Web" },
-      { name:"Prompt Tester",       slug:"prompt-tester",       icon:"💬", desc:"Test and compare AI prompts",            type:"Web" },
-      { name:"Text Summarizer",     slug:"text-summarizer",     icon:"📝", desc:"Summarize text with AI",                 type:"Web" },
       { name:"PDF Summarizer",      slug:"pdf-summarizer",      icon:"📕", desc:"Extract and summarize PDF content in-browser", type:"Web" },
       { name:"Image Analyzer",      slug:"image-analyzer",      icon:"🖼️", desc:"Inspect images with captions and metadata locally", type:"Web" },
       { name:"Code Explainer",      slug:"code-explainer",      icon:"📘", desc:"Explain snippets or files without leaving the tab", type:"Web" },

--- a/main/main.js
+++ b/main/main.js
@@ -389,6 +389,9 @@ ${urlEntries}
       // AI
       {name:"Token Counter",slug:"token-counter",category:"ai",icon:"🔢",desc:"Count tokens"},
       {name:"Context Packer",slug:"context-packer",category:"ai",icon:"📦",desc:"Pack context for LLMs"},
+      {name:"Prompt Tester",slug:"prompt-tester",category:"ai",icon:"💬",desc:"Compare prompts locally"},
+      {name:"Auto-Prompter",slug:"auto-prompter",category:"ai",icon:"🤖",desc:"Chain prompts locally"},
+      {name:"Text Summarizer",slug:"text-summarizer",category:"ai",icon:"📝",desc:"Summarize text locally"},
 
       // Tools
       {name:"Aspect Ratio",slug:"aspect-ratio",category:"tools",icon:"📐",desc:"Image dimension calculator"},
@@ -640,9 +643,6 @@ ${urlEntries}
     const WIP_TOOLS = [
       // No production index.html yet
       { name:"ASCII Art",           slug:"ascii-art",           icon:"🎨", desc:"Generate ASCII art from text",           type:"Web" },
-      { name:"Auto-Prompter",       slug:"auto-prompter",       icon:"🤖", desc:"Prompt chaining and automation",         type:"Web" },
-      { name:"Prompt Tester",       slug:"prompt-tester",       icon:"💬", desc:"Test and compare AI prompts",            type:"Web" },
-      { name:"Text Summarizer",     slug:"text-summarizer",     icon:"📝", desc:"Summarize text with AI",                 type:"Web" },
       { name:"PDF Summarizer",      slug:"pdf-summarizer",      icon:"📕", desc:"Extract and summarize PDF content in-browser", type:"Web" },
       { name:"Image Analyzer",      slug:"image-analyzer",      icon:"🖼️", desc:"Inspect images with captions and metadata locally", type:"Web" },
       { name:"Code Explainer",      slug:"code-explainer",      icon:"📘", desc:"Explain snippets or files without leaving the tab", type:"Web" },

--- a/prompt-tester/index.html
+++ b/prompt-tester/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prompt Tester — Pablobot</title>
+  <meta name="description" content="Compare and refine prompts—local helpers in this repo.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pablobot.com/prompt-tester/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pablobot.com/prompt-tester/">
+  <meta property="og:title" content="Prompt Tester — Pablobot">
+  <meta property="og:description" content="Compare and refine prompts—local helpers in this repo.">
+  <meta property="og:image" content="https://pablobot.com/main/assets/hero/architecture-gallery-hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Prompt Tester — Pablobot">
+  <meta name="twitter:description" content="Compare and refine prompts—local helpers in this repo.">
+  <meta name="theme-color" content="#0d0f17">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='%23171717'>P</text></svg>">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d0f17; --surface:#161925; --border:#2a2f45; --accent:#6c63ff; --text:#e8eaf6; --muted:#9ca3af; --radius:12px; }
+    body { font-family: system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; line-height: 1.5; }
+    a { color: var(--accent); }
+    .app-header { border-bottom: 1px solid var(--border); background: rgba(22,25,37,.92); }
+    .app-header-inner { max-width: 720px; margin: 0 auto; padding: 1rem 1.25rem; }
+    .back-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; display: inline-block; margin-bottom: 0.5rem; }
+    .back-link:hover { color: var(--text); }
+    h1 { font-size: 1.35rem; font-weight: 700; }
+    .sub { color: var(--muted); font-size: 0.9rem; margin-top: 0.25rem; }
+    .container { max-width: 720px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; margin-top: 1rem; }
+    .card p { margin-bottom: 0.75rem; color: var(--text); font-size: 0.95rem; }
+    .card p:last-child { margin-bottom: 0; }
+    .tool-more { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 1.5rem; padding: 0 1.25rem; line-height: 1.6; }
+    .tool-more a { margin: 0 0.35rem; white-space: nowrap; }
+    footer { max-width: 720px; margin: 2rem auto 0; padding: 1rem 1.25rem 2rem; border-top: 1px solid var(--border); font-size: 0.78rem; color: var(--muted); text-align: center; }
+  </style>
+</head>
+<body>
+  <header class="app-header">
+    <div class="app-header-inner">
+      <a class="back-link" href="../">← Pablobot</a>
+      <h1>Prompt Tester</h1>
+      <p class="sub">Compare prompts with small local helpers.</p>
+    </div>
+  </header>
+  <main class="container">
+    <div class="card">
+      <p>This folder holds a lightweight CLI for testing prompts. Nothing runs in the browser here.</p>
+      <p><a href="https://github.com/Catalitium/pablot/tree/main/prompt-tester">View source on GitHub</a></p>
+    </div>
+  </main>
+  <nav class="tool-more" aria-label="More Pablobot utilities">
+    Also try:
+    <a href="/token-counter/">Token Counter</a>
+    <a href="/context-packer/">Context Packer</a>
+    <a href="/json-formatter/">JSON Formatter</a>
+  </nav>
+  <footer>Open source · Part of <a href="../">Pablobot</a></footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,6 +5,7 @@
   <url><loc>https://pablobot.com/ascii-table/</loc></url>
   <url><loc>https://pablobot.com/aspect-ratio/</loc></url>
   <url><loc>https://pablobot.com/audio-visualizer/</loc></url>
+  <url><loc>https://pablobot.com/auto-prompter/</loc></url>
   <url><loc>https://pablobot.com/base64/</loc></url>
   <url><loc>https://pablobot.com/binary-converter/</loc></url>
   <url><loc>https://pablobot.com/case-converter/</loc></url>
@@ -91,6 +92,7 @@
   <url><loc>https://pablobot.com/matrix-calculator/</loc></url>
   <url><loc>https://pablobot.com/password-generator/</loc></url>
   <url><loc>https://pablobot.com/pomodoro-timer/</loc></url>
+  <url><loc>https://pablobot.com/prompt-tester/</loc></url>
   <url><loc>https://pablobot.com/qr-generator/</loc></url>
   <url><loc>https://pablobot.com/reading-estimator/</loc></url>
   <url><loc>https://pablobot.com/regex-tester/</loc></url>
@@ -98,6 +100,7 @@
   <url><loc>https://pablobot.com/solar-system/</loc></url>
   <url><loc>https://pablobot.com/sql-builder/</loc></url>
   <url><loc>https://pablobot.com/system-health/</loc></url>
+  <url><loc>https://pablobot.com/text-summarizer/</loc></url>
   <url><loc>https://pablobot.com/timezone-converter/</loc></url>
   <url><loc>https://pablobot.com/token-counter/</loc></url>
   <url><loc>https://pablobot.com/typing-test/</loc></url>

--- a/text-summarizer/index.html
+++ b/text-summarizer/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Text Summarizer — Pablobot</title>
+  <meta name="description" content="Summarize text with local helpers in this repo.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://pablobot.com/text-summarizer/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://pablobot.com/text-summarizer/">
+  <meta property="og:title" content="Text Summarizer — Pablobot">
+  <meta property="og:description" content="Summarize text with local helpers in this repo.">
+  <meta property="og:image" content="https://pablobot.com/main/assets/hero/architecture-gallery-hero.webp">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Text Summarizer — Pablobot">
+  <meta name="twitter:description" content="Summarize text with local helpers in this repo.">
+  <meta name="theme-color" content="#0d0f17">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90' fill='%23171717'>P</text></svg>">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d0f17; --surface:#161925; --border:#2a2f45; --accent:#6c63ff; --text:#e8eaf6; --muted:#9ca3af; --radius:12px; }
+    body { font-family: system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; line-height: 1.5; }
+    a { color: var(--accent); }
+    .app-header { border-bottom: 1px solid var(--border); background: rgba(22,25,37,.92); }
+    .app-header-inner { max-width: 720px; margin: 0 auto; padding: 1rem 1.25rem; }
+    .back-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; display: inline-block; margin-bottom: 0.5rem; }
+    .back-link:hover { color: var(--text); }
+    h1 { font-size: 1.35rem; font-weight: 700; }
+    .sub { color: var(--muted); font-size: 0.9rem; margin-top: 0.25rem; }
+    .container { max-width: 720px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; margin-top: 1rem; }
+    .card p { margin-bottom: 0.75rem; color: var(--text); font-size: 0.95rem; }
+    .card p:last-child { margin-bottom: 0; }
+    .tool-more { font-size: 0.8rem; color: var(--muted); text-align: center; margin-top: 1.5rem; padding: 0 1.25rem; line-height: 1.6; }
+    .tool-more a { margin: 0 0.35rem; white-space: nowrap; }
+    footer { max-width: 720px; margin: 2rem auto 0; padding: 1rem 1.25rem 2rem; border-top: 1px solid var(--border); font-size: 0.78rem; color: var(--muted); text-align: center; }
+  </style>
+</head>
+<body>
+  <header class="app-header">
+    <div class="app-header-inner">
+      <a class="back-link" href="../">← Pablobot</a>
+      <h1>Text Summarizer</h1>
+      <p class="sub">Summarize text with local helpers.</p>
+    </div>
+  </header>
+  <main class="container">
+    <div class="card">
+      <p>This folder holds a small Python entrypoint for summarization workflows. Nothing runs in the browser here.</p>
+      <p><a href="https://github.com/Catalitium/pablot/tree/main/text-summarizer">View source on GitHub</a></p>
+    </div>
+  </main>
+  <nav class="tool-more" aria-label="More Pablobot utilities">
+    Also try:
+    <a href="/token-counter/">Token Counter</a>
+    <a href="/context-packer/">Context Packer</a>
+    <a href="/json-formatter/">JSON Formatter</a>
+  </nav>
+  <footer>Open source · Part of <a href="../">Pablobot</a></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Moves three lab entries into live \TOOLS\ (AI tab), adds minimal static \index.html\ per slug so hub links resolve, syncs README + \sitemap.xml\, flattens root hub (\main.js\, \index.html\).

## Notes
- Static pages: calm copy + GitHub source links; CLI helpers stay in repo folders.
- Untracked tool dirs on disk intentionally excluded from this PR.

Made with [Cursor](https://cursor.com)